### PR TITLE
For new issue - Lowercase Commands and Commands with and without underscore

### DIFF
--- a/src/main/java/seedu/planner/logic/commands/AddLimitCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/AddLimitCommand.java
@@ -14,8 +14,9 @@ import seedu.planner.model.record.Limit;
 * and the command will check whether the the total expense during this period has exceeded the limit.
  * and the limit will be stored inside the limit storage.
 * */
-public class LimitCommand extends Command {
-    public static final String COMMAND_WORD = "limit";
+public class AddLimitCommand extends Command {
+    public static final String COMMAND_WORD = "addlimit";
+    public static final String COMMAND_WORD_UNDERSCORE = "add_limit";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Check the limit for a period of time. "
             + "Parameters: "
             + PREFIX_DATE + "DATE_START " + "DATE_END "
@@ -40,7 +41,7 @@ public class LimitCommand extends Command {
 
     private String output;
 
-    public LimitCommand (Limit limitIn) {
+    public AddLimitCommand (Limit limitIn) {
         requireNonNull(limitIn);
         limit = limitIn;
 
@@ -64,7 +65,7 @@ public class LimitCommand extends Command {
     @Override
     public boolean equals (Object other) {
         return other == this // short circuit if same object
-                || (other instanceof LimitCommand // instanceof handles nulls
-                && limit.equals(((LimitCommand) other).limit));
+                || (other instanceof AddLimitCommand // instanceof handles nulls
+                && limit.equals(((AddLimitCommand) other).limit));
     }
 }

--- a/src/main/java/seedu/planner/logic/commands/CheckLimitCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/CheckLimitCommand.java
@@ -10,7 +10,8 @@ import seedu.planner.model.Model;
  * This function will print out all the limit information.
  */
 public class CheckLimitCommand extends Command {
-    public static final String COMMAND_WORD = "checkLimit";
+    public static final String COMMAND_WORD = "checklimit";
+    public static final String COMMAND_WORD_UNDERSCORE = "check_limit";
     public static final String MESSAGE_SUCCESS = "Listed all limits";
     public static final String MESSAGE_FAILURE = "No more limits to list!";
 

--- a/src/main/java/seedu/planner/logic/commands/DeleteCommandByDateEntry.java
+++ b/src/main/java/seedu/planner/logic/commands/DeleteCommandByDateEntry.java
@@ -17,7 +17,8 @@ import seedu.planner.model.record.Record;
  * Delete the records whose date is required.
  */
 public class DeleteCommandByDateEntry extends Command {
-    public static final String COMMAND_WORD = "delete_date";
+    public static final String COMMAND_WORD = "deletedate";
+    public static final String COMMAND_WORD_UNDERSCORE = "delete_date";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the all records identified by the date number used in the displayed record list.\n"
             + "PARAMERERS: DATE (Must follow the format dd-mm-yyyy).\n"

--- a/src/main/java/seedu/planner/logic/commands/DeleteLimitCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/DeleteLimitCommand.java
@@ -14,7 +14,8 @@ import seedu.planner.model.record.Limit;
  * report an error.
  */
 public class DeleteLimitCommand extends Command {
-    public static final String COMMAND_WORD = "deleteLimit";
+    public static final String COMMAND_WORD = "deletelimit";
+    public static final String COMMAND_WORD_UNDERSCORE = "delete_limit";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": delete certain limit according to the dates. "
             + "Parameters: "
             + PREFIX_DATE + "DATE_START " + "DATE_END " + "\n"

--- a/src/main/java/seedu/planner/logic/commands/EditLimitCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/EditLimitCommand.java
@@ -15,7 +15,8 @@ import seedu.planner.model.record.Limit;
  * The newly input limit will replace the old limit.
  */
 public class EditLimitCommand extends Command {
-    public static final String COMMAND_WORD = "editLimit";
+    public static final String COMMAND_WORD = "editlimit";
+    public static final String COMMAND_WORD_UNDERSCORE = "edit_limit";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edit an existing limit according to the dates. "
             + "Parameters: "
             + PREFIX_DATE + "DATE_START " + "DATE_END "

--- a/src/main/java/seedu/planner/logic/commands/ExportExcelCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/ExportExcelCommand.java
@@ -22,7 +22,8 @@ import seedu.planner.model.record.Record;
  * Export the data of the records within specific period.
  */
 public class ExportExcelCommand extends Command {
-    public static final String COMMAND_WORD = "export_excel";
+    public static final String COMMAND_WORD = "exportexcel";
+    public static final String COMMAND_WORD_UNDERSCORE = "export_excel";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Export the records data into Excel file within specific period.\n"
             + "The file will be named in format: Financial_Planner_STARTDATE_ENDDATE.\n"

--- a/src/main/java/seedu/planner/logic/commands/FindTagCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/FindTagCommand.java
@@ -14,7 +14,7 @@ import seedu.planner.model.record.TagsContainsKeywordsPredicate;
 public class FindTagCommand extends Command {
 
     public static final String COMMAND_WORD = "findtag";
-
+    public static final String COMMAND_WORD_UNDERSCORE = "find_tag";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all records whose tags contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"

--- a/src/main/java/seedu/planner/logic/parser/AddLimitCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/AddLimitCommandParser.java
@@ -6,7 +6,7 @@ import static seedu.planner.logic.parser.CliSyntax.PREFIX_MONEYFLOW;
 
 import java.util.stream.Stream;
 
-import seedu.planner.logic.commands.LimitCommand;
+import seedu.planner.logic.commands.AddLimitCommand;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.record.Date;
 import seedu.planner.model.record.Limit;
@@ -15,9 +15,9 @@ import seedu.planner.model.record.MoneyFlow;
 
 
 /**
-* The Parser will parse those values in one format Limit and return back to LimitCommand.
+* The Parser will parse those values in one format Limit and return back to AddLimitCommand.
 * */
-public class LimitCommandParser implements Parser<LimitCommand> {
+public class AddLimitCommandParser implements Parser<AddLimitCommand> {
     /**
      * Parses the information required for the limit command.
      * and returns a limit object for execution.
@@ -28,13 +28,13 @@ public class LimitCommandParser implements Parser<LimitCommand> {
     private String moneyString;
 
     @Override
-    public LimitCommand parse(String args) throws ParseException {
+    public AddLimitCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_MONEYFLOW);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_MONEYFLOW)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LimitCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLimitCommand.MESSAGE_USAGE));
         }
         moneyString = "-" + argMultimap.getValue(PREFIX_MONEYFLOW).get();
 
@@ -54,7 +54,7 @@ public class LimitCommandParser implements Parser<LimitCommand> {
         Limit limit = new Limit(dateStart, dateEnd, money);
 
 
-        return new LimitCommand(limit);
+        return new AddLimitCommand(limit);
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/planner/logic/parser/EditLimitCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/EditLimitCommandParser.java
@@ -13,7 +13,7 @@ import seedu.planner.model.record.MoneyFlow;
 
 
 /**
- * This command Parser is very similar to the @LimitCommandParser.
+ * This command Parser is very similar to the @AddLimitCommandParser.
  * Will return the editLimitCommand with the given limit.
  */
 public class EditLimitCommandParser implements Parser <EditLimitCommand> {

--- a/src/main/java/seedu/planner/logic/parser/FinancialPlannerParser.java
+++ b/src/main/java/seedu/planner/logic/parser/FinancialPlannerParser.java
@@ -57,7 +57,7 @@ public class FinancialPlannerParser {
         }
 
         final String commandWord = matcher.group("commandWord").toLowerCase();
-        final String arguments = matcher.group("arguments").toLowerCase();
+        final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
 
@@ -83,13 +83,13 @@ public class FinancialPlannerParser {
             return new FindCommandParser().parse(arguments);
 
         case FindTagCommand.COMMAND_WORD: case FindTagCommand.COMMAND_WORD_UNDERSCORE:
-            return new FindTagCommandParser().parse(arguments);
+            return new FindTagCommandParser().parse(arguments.toLowerCase());
 
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);
 
         case SortCommand.COMMAND_WORD:
-            return new SortCommandParser().parse(arguments);
+            return new SortCommandParser().parse(arguments.toLowerCase());
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/planner/logic/parser/FinancialPlannerParser.java
+++ b/src/main/java/seedu/planner/logic/parser/FinancialPlannerParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.planner.logic.commands.AddCommand;
+import seedu.planner.logic.commands.AddLimitCommand;
 import seedu.planner.logic.commands.CheckLimitCommand;
 import seedu.planner.logic.commands.ClearCommand;
 import seedu.planner.logic.commands.Command;
@@ -21,7 +22,6 @@ import seedu.planner.logic.commands.FindCommand;
 import seedu.planner.logic.commands.FindTagCommand;
 import seedu.planner.logic.commands.HelpCommand;
 import seedu.planner.logic.commands.HistoryCommand;
-import seedu.planner.logic.commands.LimitCommand;
 import seedu.planner.logic.commands.ListCommand;
 import seedu.planner.logic.commands.RedoCommand;
 import seedu.planner.logic.commands.SelectCommand;
@@ -56,8 +56,8 @@ public class FinancialPlannerParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
+        final String arguments = matcher.group("arguments").toLowerCase();
 
         switch (commandWord) {
 
@@ -73,7 +73,7 @@ public class FinancialPlannerParser {
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
 
-        case DeleteCommandByDateEntry.COMMAND_WORD:
+        case DeleteCommandByDateEntry.COMMAND_WORD: case DeleteCommandByDateEntry.COMMAND_WORD_UNDERSCORE:
             return new DeleteCommandByDateEntryParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
@@ -82,7 +82,7 @@ public class FinancialPlannerParser {
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
-        case FindTagCommand.COMMAND_WORD:
+        case FindTagCommand.COMMAND_WORD: case FindTagCommand.COMMAND_WORD_UNDERSCORE:
             return new FindTagCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
@@ -106,23 +106,25 @@ public class FinancialPlannerParser {
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
 
-        case LimitCommand.COMMAND_WORD:
-            return new LimitCommandParser().parse(arguments);
+        case AddLimitCommand.COMMAND_WORD: case AddLimitCommand.COMMAND_WORD_UNDERSCORE:
+            return new AddLimitCommandParser().parse(arguments);
 
-        case DeleteLimitCommand.COMMAND_WORD:
+        case DeleteLimitCommand.COMMAND_WORD: case DeleteLimitCommand.COMMAND_WORD_UNDERSCORE:
             return new DeleteLimitCommandParser().parse(arguments);
 
-        case EditLimitCommand.COMMAND_WORD:
+        case EditLimitCommand.COMMAND_WORD: case EditLimitCommand.COMMAND_WORD_UNDERSCORE:
             return new EditLimitCommandParser().parse(arguments);
-        case CheckLimitCommand.COMMAND_WORD:
+
+        case CheckLimitCommand.COMMAND_WORD: case CheckLimitCommand.COMMAND_WORD_UNDERSCORE:
             return new CheckLimitCommand();
+
         case SummaryCommand.COMMAND_WORD:
             return new SummaryCommandParser().parse(arguments);
 
         case StatisticCommand.COMMAND_WORD:
             return new StatisticCommandParser().parse(arguments);
 
-        case ExportExcelCommand.COMMAND_WORD:
+        case ExportExcelCommand.COMMAND_WORD: case ExportExcelCommand.COMMAND_WORD_UNDERSCORE:
             return new ExportExcelCommandParser().parse(arguments);
 
 

--- a/src/main/java/seedu/planner/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/SortCommandParser.java
@@ -34,10 +34,10 @@ public class SortCommandParser implements Parser<SortCommand> {
         String[] argList = trimmedArgs.split("\\s+");
 
         if ((argList.length) == ONLY_CATEGORY_OR_ORDER_SPECIFIED) {
-            if (!CATEGORY_SET.contains(argList[0].toLowerCase()) && !ORDER_SET.contains(argList[0].toLowerCase())) {
+            if (!CATEGORY_SET.contains(argList[0]) && !ORDER_SET.contains(argList[0])) {
                 throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)));
             }
-            category = argList[0].toLowerCase();
+            category = argList[0];
             ascending = true;
             if (category.equals(DESCENDING_CONDITION)) {
                 category = CATEGORY_NAME;
@@ -46,15 +46,15 @@ public class SortCommandParser implements Parser<SortCommand> {
                 category = CATEGORY_NAME;
             }
         } else if (argList.length == CATEGORY_AND_ORDER_SPECIFIED) {
-            if ((ORDER_SET.contains(argList[0].toLowerCase()) || ORDER_SET.contains(argList[1].toLowerCase()))
-                    && (CATEGORY_SET.contains(argList[0].toLowerCase())
-                    || CATEGORY_SET.contains(argList[1].toLowerCase()))) {
-                if (ORDER_SET.contains(argList[0].toLowerCase())) {
-                    ascending = !(argList[0].toLowerCase().equals(DESCENDING_CONDITION));
-                    category = argList[1].toLowerCase();
+            if ((ORDER_SET.contains(argList[0]) || ORDER_SET.contains(argList[1]))
+                    && (CATEGORY_SET.contains(argList[0])
+                    || CATEGORY_SET.contains(argList[1]))) {
+                if (ORDER_SET.contains(argList[0])) {
+                    ascending = !(argList[0].equals(DESCENDING_CONDITION));
+                    category = argList[1];
                 } else {
-                    ascending = (argList[1].toLowerCase().equals(ASCENDING_CONDITION));
-                    category = argList[0].toLowerCase();
+                    ascending = (argList[1].equals(ASCENDING_CONDITION));
+                    category = argList[0];
                 }
             } else {
                 throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)));

--- a/src/main/java/seedu/planner/model/ModelManager.java
+++ b/src/main/java/seedu/planner/model/ModelManager.java
@@ -2,10 +2,10 @@ package seedu.planner.model;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.planner.logic.commands.LimitCommand.MESSAGE_BASIC_EARNED;
-import static seedu.planner.logic.commands.LimitCommand.MESSAGE_BASIC_SPEND;
-import static seedu.planner.logic.commands.LimitCommand.MESSAGE_EXCEED;
-import static seedu.planner.logic.commands.LimitCommand.MESSAGE_NOT_EXCEED;
+import static seedu.planner.logic.commands.AddLimitCommand.MESSAGE_BASIC_EARNED;
+import static seedu.planner.logic.commands.AddLimitCommand.MESSAGE_BASIC_SPEND;
+import static seedu.planner.logic.commands.AddLimitCommand.MESSAGE_EXCEED;
+import static seedu.planner.logic.commands.AddLimitCommand.MESSAGE_NOT_EXCEED;
 
 import java.util.List;
 import java.util.function.Predicate;

--- a/src/main/java/seedu/planner/ui/CustomSuggestionProvider.java
+++ b/src/main/java/seedu/planner/ui/CustomSuggestionProvider.java
@@ -11,10 +11,12 @@ import java.util.stream.Stream;
 
 import impl.org.controlsfx.autocompletion.SuggestionProvider;
 import seedu.planner.logic.commands.AddCommand;
+import seedu.planner.logic.commands.AddLimitCommand;
 import seedu.planner.logic.commands.CheckLimitCommand;
 import seedu.planner.logic.commands.ClearCommand;
 import seedu.planner.logic.commands.DeleteCommand;
 import seedu.planner.logic.commands.DeleteCommandByDateEntry;
+import seedu.planner.logic.commands.DeleteLimitCommand;
 import seedu.planner.logic.commands.EditCommand;
 import seedu.planner.logic.commands.EditLimitCommand;
 import seedu.planner.logic.commands.ExitCommand;
@@ -23,7 +25,6 @@ import seedu.planner.logic.commands.FindCommand;
 import seedu.planner.logic.commands.FindTagCommand;
 import seedu.planner.logic.commands.HelpCommand;
 import seedu.planner.logic.commands.HistoryCommand;
-import seedu.planner.logic.commands.LimitCommand;
 import seedu.planner.logic.commands.ListCommand;
 import seedu.planner.logic.commands.RedoCommand;
 import seedu.planner.logic.commands.SelectCommand;
@@ -44,14 +45,24 @@ public class CustomSuggestionProvider {
     private static Pattern pattern = Pattern.compile(patternStr);
 
     private static Set<String> commandKeywordsSet =
-            new HashSet<>(Arrays.asList(AddCommand.COMMAND_WORD, CheckLimitCommand.COMMAND_WORD,
-                    ClearCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD, DeleteCommandByDateEntry.COMMAND_WORD,
-                    EditCommand.COMMAND_WORD, EditLimitCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD,
-                    ExportExcelCommand.COMMAND_WORD, FindCommand.COMMAND_WORD, FindTagCommand.COMMAND_WORD,
-                    HelpCommand.COMMAND_WORD, HistoryCommand.COMMAND_WORD, LimitCommand.COMMAND_WORD,
+            new HashSet<>(Arrays.asList(AddCommand.COMMAND_WORD, AddLimitCommand.COMMAND_WORD,
+                    CheckLimitCommand.COMMAND_WORD, ClearCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD,
+                    DeleteCommandByDateEntry.COMMAND_WORD, DeleteLimitCommand.COMMAND_WORD,
+                    EditCommand.COMMAND_WORD, EditLimitCommand.COMMAND_WORD,
+                    ExitCommand.COMMAND_WORD, ExportExcelCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
+                    FindTagCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD, HistoryCommand.COMMAND_WORD,
                     ListCommand.COMMAND_WORD, RedoCommand.COMMAND_WORD, SelectCommand.COMMAND_WORD,
                     SortCommand.COMMAND_WORD, StatisticCommand.COMMAND_WORD, SummaryCommand.COMMAND_WORD,
                     UndoCommand.COMMAND_WORD));
+
+    private static Set<String> commandKeywordsUnderscoreSet =
+            new HashSet<>(Arrays.asList(AddLimitCommand.COMMAND_WORD_UNDERSCORE,
+                    CheckLimitCommand.COMMAND_WORD_UNDERSCORE, DeleteCommandByDateEntry.COMMAND_WORD_UNDERSCORE,
+                    DeleteLimitCommand.COMMAND_WORD_UNDERSCORE, EditLimitCommand.COMMAND_WORD_UNDERSCORE,
+                    ExportExcelCommand.COMMAND_WORD_UNDERSCORE, FindTagCommand.COMMAND_WORD_UNDERSCORE));
+
+    private static Set<String> fullCommandKeywordsSet = Stream.concat(commandKeywordsSet.stream(),
+            commandKeywordsUnderscoreSet.stream()).collect(Collectors.toSet());
 
     private static Set<String> summaryKeywordsSet = new HashSet<>(Arrays.asList(SummaryByMonthCommand.COMMAND_MODE_WORD,
             SummaryByDateCommand.COMMAND_MODE_WORD));
@@ -114,7 +125,7 @@ public class CustomSuggestionProvider {
             }
         } else if (inputs[0].equals(FindTagCommand.COMMAND_WORD) && inputs.length > 1) {
             updateSuggestions(tagKeywordsMap.keySet());
-        } else if (commandKeywordsSet.contains(inputs[0]) || inputs.length > 1) {
+        } else if (fullCommandKeywordsSet.contains(inputs[0]) || inputs.length > 1) {
             updateSuggestions(emptySet);
         } else {
             updateSuggestions(commandKeywordsSet);

--- a/src/test/java/seedu/planner/logic/commands/AddLimitCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/AddLimitCommandTest.java
@@ -26,7 +26,7 @@ import seedu.planner.model.record.Record;
 import seedu.planner.testutil.LimitBuilder;
 
 
-public class LimitCommandTest {
+public class AddLimitCommandTest {
 
     private static final CommandHistory EMPTY_COMMAND_HISTORY = new CommandHistory();
 
@@ -38,7 +38,7 @@ public class LimitCommandTest {
     @Test
     public void constructor_nullLimit_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        new LimitCommand(null);
+        new AddLimitCommand(null);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class LimitCommandTest {
         ModelStubAcceptingLimitAdded modelStub = new ModelStubAcceptingLimitAdded();
         Limit validLimit = new LimitBuilder().build();
 
-        CommandResult commandResult = new LimitCommand(validLimit).execute(modelStub, commandHistory);
+        CommandResult commandResult = new AddLimitCommand(validLimit).execute(modelStub, commandHistory);
 
         assertEquals(modelStub.generateLimitOutput(false,
                 modelStub.getTotalSpend(validLimit), validLimit), commandResult.feedbackToUser);
@@ -57,11 +57,11 @@ public class LimitCommandTest {
     @Test
     public void execute_sameDatesLimit_throwsCommandException() throws Exception {
         Limit validLimit = new LimitBuilder().build();
-        LimitCommand limitCommand = new LimitCommand(validLimit);
+        AddLimitCommand limitCommand = new AddLimitCommand(validLimit);
         ModelStub modelStub = new ModelStubWithLimit(validLimit);
 
         thrown.expect(CommandException.class);
-        thrown.expectMessage(LimitCommand.MESSAGE_LIMITS_SAME_DATE);
+        thrown.expectMessage(AddLimitCommand.MESSAGE_LIMITS_SAME_DATE);
         limitCommand.execute(modelStub, commandHistory);
     }
 
@@ -69,14 +69,14 @@ public class LimitCommandTest {
     public void equals() {
         Limit limit = new LimitBuilder().withMoneyFlow("-100").build();
         Limit limitD = new LimitBuilder().withDateStart("16-12-1998").build();
-        LimitCommand limitCommand = new LimitCommand(limit);
-        LimitCommand limitDCommand = new LimitCommand(limitD);
+        AddLimitCommand limitCommand = new AddLimitCommand(limit);
+        AddLimitCommand limitDCommand = new AddLimitCommand(limitD);
 
         // same object -> returns true
         assertTrue(limitCommand.equals(limitCommand));
 
         // same values -> returns true
-        LimitCommand limitCommandCopy = new LimitCommand(limit);
+        AddLimitCommand limitCommandCopy = new AddLimitCommand(limit);
         assertTrue(limitCommand.equals(limitCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -52,8 +52,6 @@ public class ClearCommandSystemTest extends FinancialPlannerSystemTest {
         assertCommandSuccess(ClearCommand.COMMAND_WORD);
         assertSelectedCardUnchanged();
 
-        /* Case: mixed case command word -> rejected */
-        assertCommandFailure("ClEaR", MESSAGE_UNKNOWN_COMMAND);
     }
 
     /**

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -1,6 +1,5 @@
 package systemtests;
 
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.planner.testutil.TypicalRecords.KEYWORD_MATCHING_BURSARY;
 
 import org.junit.Test;

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -2,7 +2,6 @@ package systemtests;
 
 import static org.junit.Assert.assertTrue;
 import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_RECORD_DISPLAYED_INDEX;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.planner.logic.commands.DeleteCommand.MESSAGE_DELETE_RECORD_SUCCESS;
 import static seedu.planner.testutil.TestUtil.getLastIndex;
 import static seedu.planner.testutil.TestUtil.getMidIndex;

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -113,8 +113,6 @@ public class DeleteCommandSystemTest extends FinancialPlannerSystemTest {
         /* Case: invalid arguments (extra argument) -> rejected */
         assertCommandFailure(DeleteCommand.COMMAND_WORD + " 1 abc", MESSAGE_INVALID_DELETE_COMMAND_FORMAT);
 
-        /* Case: mixed case command word -> rejected */
-        assertCommandFailure("DelETE 1", MESSAGE_UNKNOWN_COMMAND);
     }
 
     /**

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -146,9 +146,6 @@ public class FindCommandSystemTest extends FinancialPlannerSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: mixed case command word -> rejected */
-        command = "FiNd Income";
-        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
     }
 
     /**

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -2,7 +2,6 @@ package systemtests;
 
 import static org.junit.Assert.assertFalse;
 import static seedu.planner.commons.core.Messages.MESSAGE_RECORDS_LISTED_OVERVIEW;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.planner.testutil.TypicalRecords.CAIFAN;
 import static seedu.planner.testutil.TypicalRecords.KEYWORD_MATCHING_BURSARY;
 import static seedu.planner.testutil.TypicalRecords.RANDOM;

--- a/src/test/java/systemtests/FindTagCommandSystemTest.java
+++ b/src/test/java/systemtests/FindTagCommandSystemTest.java
@@ -140,9 +140,6 @@ public class FindTagCommandSystemTest extends FinancialPlannerSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: mixed case command word -> rejected */
-        command = "fINDtAG friends";
-        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
     }
 
     /**

--- a/src/test/java/systemtests/FindTagCommandSystemTest.java
+++ b/src/test/java/systemtests/FindTagCommandSystemTest.java
@@ -2,7 +2,6 @@ package systemtests;
 
 import static org.junit.Assert.assertFalse;
 import static seedu.planner.commons.core.Messages.MESSAGE_RECORDS_LISTED_OVERVIEW;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.planner.testutil.TypicalRecords.CAIFAN;
 import static seedu.planner.testutil.TypicalRecords.IDA;
 import static seedu.planner.testutil.TypicalRecords.INDO;

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -89,9 +89,6 @@ public class SelectCommandSystemTest extends FinancialPlannerSystemTest {
         assertCommandFailure(SelectCommand.COMMAND_WORD + " 1 abc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
 
-        /* Case: mixed case command word -> rejected */
-        assertCommandFailure("SeLeCt 1", MESSAGE_UNKNOWN_COMMAND);
-
         /* Case: select from empty planner book -> rejected */
         deleteAllRecords();
         assertCommandFailure(SelectCommand.COMMAND_WORD + " " + INDEX_FIRST_RECORD.getOneBased(),

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -3,7 +3,6 @@ package systemtests;
 import static org.junit.Assert.assertTrue;
 import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_RECORD_DISPLAYED_INDEX;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.planner.logic.commands.SelectCommand.MESSAGE_SELECT_RECORD_SUCCESS;
 import static seedu.planner.testutil.TestUtil.getLastIndex;
 import static seedu.planner.testutil.TestUtil.getMidIndex;


### PR DESCRIPTION
All commands are now standardised all in small letters, and support both with underscore spacing and without - for words that are made up of 2 or more actual words. 
Also updated the suggestions, UI will only suggest the non-underscore format, but if the user decides to still enter with the underscore, the command still works and is considered an actual command.